### PR TITLE
Fix for console errors on pages that don't have a title

### DIFF
--- a/dist/js/content.min.js
+++ b/dist/js/content.min.js
@@ -112,11 +112,13 @@ chrome.storage.local.get('tab_modifier', function (items) {
     });
 
     // Observe when the website has changed the title
-    observer.observe(document.querySelector('head > title'), {
-        subtree: true,
-        characterresponse: true,
-        childList: true
-    });
+    if (document.querySelector('head > title') !== null) {
+        observer.observe(document.querySelector('head > title'), {
+            subtree: true,
+            characterresponse: true,
+            childList: true
+        });
+    }
 
     // Pin the tab
     if (rule.tab.pinned === true) {

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -112,11 +112,13 @@ chrome.storage.local.get('tab_modifier', function (items) {
     });
 
     // Observe when the website has changed the title
-    observer.observe(document.querySelector('head > title'), {
-        subtree: true,
-        characterresponse: true,
-        childList: true
-    });
+    if (document.querySelector('head > title') !== null) {
+        observer.observe(document.querySelector('head > title'), {
+            subtree: true,
+            characterresponse: true,
+            childList: true
+        });
+    }
 
     // Pin the tab
     if (rule.tab.pinned === true) {


### PR DESCRIPTION
This may be a low priority, but it was kind of annoying constantly getting console error messages when there's no errors in the page.