### PR TITLE
Allow data: URIs in icons

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -153,8 +153,8 @@ chrome.storage.local.get('tab_modifier', function (items) {
             node.parentNode.removeChild(node);
         });
 
-        // Set preconfigured or custom ("http" catched) icon
-        icon = (rule.tab.icon.indexOf('http') === -1) ? chrome.extension.getURL('/img/' + rule.tab.icon) : rule.tab.icon;
+        // Set preconfigured or custom (http|https|data) icon
+        icon = /^(https?|data):/.test(rule.tab.icon) ? rule.tab.icon : chrome.extension.getURL('/img/' + rule.tab.icon);
 
         // Create new favicon
         link      = document.createElement('link');


### PR DESCRIPTION
This pull request aims to accept `data:` URIs as custom icons.

In the future, the extension may accept local files and can convert them to `data:` URIs. That would be a nice solution for the local file limitation. Still, that's a suggestion of a future step.

(Please read the commit message.)