### PR TITLE
remove unmatched selectors from title

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -104,6 +104,9 @@ chrome.storage.local.get('tab_modifier', function (items) {
                     text     = getTextBySelector(selector);
                     title    = updateTitle(title, matches[i], text);
                 }
+
+                // Remove unmatched selectors from title
+                title = title.replace(/\{([^}]+)}/g, '');
             }
             
             // Handle title_matcher


### PR DESCRIPTION
I've been using this extension for a few months. Recently, I noticed that it could benefit by removing unmatched selectors from the title.