### PR TITLE
Fix/Travis CI tests failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 
 node_js:
-    - "5"
+    - "9"
 
 script:
     - gulp tests

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,13 +17,14 @@ module.exports = function(config) {
 
         // list of files / patterns to load in the browser
         files: [
-            'https://ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular.min.js',
-            'https://ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular-route.min.js',
-            'https://ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular-animate.min.js',
-            'https://ajax.googleapis.com/ajax/libs/angularjs/1.5.8/angular-aria.min.js',
+            'node_modules/angular/angular.js',
+            'node_modules/angular-animate/angular-animate.js',
+            'node_modules/angular-aria/angular-aria.js',
+            'node_modules/angular-material/angular-material.js',
+            'node_modules/angular-google-analytics/dist/angular-google-analytics.js',
+            'node_modules/angular-route/angular-route.js',
+            'node_modules/angular-ui-tree/dist/angular-ui-tree.js',
             'node_modules/angular-mocks/angular-mocks.js',
-            'https://ajax.googleapis.com/ajax/libs/angular_material/1.1.0-rc.5/angular-material.min.js',
-            'dist/js/libs/libs.min.js',
             'dist/js/options.js',
             'tests/**/*.js',
             {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,14 @@
     "url": "https://github.com/sylouuu/chrome-tab-modifier/issues"
   },
   "devDependencies": {
-    "angular-mocks": "1.5.8",
+    "angular": "~1.6.0",
+    "angular-aria": "~1.6.0",
+    "angular-animate": "~1.6.0",
+    "angular-google-analytics":"~1.1.8",
+    "angular-material":"~1.1.7",
+    "angular-mocks": "~1.6.0",
+    "angular-route": "~1.6.0",
+    "angular-ui-tree":"~2.22.6",
     "gulp": "^3.9.1",
     "gulp-concat": "~2.6.0",
     "gulp-jscs": "~4.1.0",


### PR DESCRIPTION
Hi

Tests are failing on Travis CI because the conf was a little outdated.
I fixed the dependencies and the tests are now [passing](https://travis-ci.org/clfer/chrome-tab-modifier/branches) on this branch.

Have a good day 